### PR TITLE
支持 iOS 手机 QQ 的 ua 识别

### DIFF
--- a/lib/useragent-base.js
+++ b/lib/useragent-base.js
@@ -2525,7 +2525,7 @@ module.exports = (function () {
         initialize: function (v) {
             this.original = v.value || null;
             this.alias = v.alias || null;
-            
+
         }
     }
 
@@ -2688,7 +2688,7 @@ module.exports = (function () {
              *      iOS
              */
 
-            if (ua.match('iPhone( Simulator)?;') || ua.match('iPad;') || ua.match('iPod;') || ua.match(/iPhone\s*\d*s?c?;/i)) {
+            if (ua.match('iPhone( Simulator)?;') || ua.match('iPad;') || ua.match('iPod;') || ua.match(/iPhone(\s+\d+(sp?|c)?)?;/i)) {
                 this.os.name = 'iOS';
                 this.os.version = new Version({
                     value: '1.0'
@@ -2706,7 +2706,7 @@ module.exports = (function () {
                     this.device.type = 'media';
                     this.device.manufacturer = 'Apple';
                     this.device.model = 'iPod Touch';
-                } else if (ua.match('iPhone;') || ua.match(/iPhone\s*\d*s?c?;/i)) {
+                } else if (ua.match('iPhone;') || ua.match(/iPhone(\s+\d+(sp?|c)?)?;/i)) {
                     this.device.type = 'mobile';
                     this.device.manufacturer = 'Apple';
                     this.device.model = 'iPhone';

--- a/test/index.js
+++ b/test/index.js
@@ -70,3 +70,27 @@ describe('ua-device测试数据共'+total_test_num+'条', function() {
 		});
 	}
 });
+
+
+
+
+
+
+
+
+
+describe('ios 手机 QQ 支持', function () {
+	var uaList = [
+		'Mozilla/5.0 (iPhone 6sp; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 MQQBrowser/7.3 Mobile/14E304 Safari/8536.25 MttCustomUA/2 QBWebViewType/1',
+		'Mozilla/5.0 (iPhone 6sp; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 MQQBrowser/7.4 Mobile/13G36 Safari/8536.25 MttCustomUA/2 QBWebViewType/1 WKType/1'
+	];
+	uaList.forEach(function (ua) {
+
+		it('测试 ua：\n    ' + ua, function () {
+			var uaData = new UA(ua);
+
+			assert.equal(uaData.device.model, 'IPHONE');
+			assert.equal(uaData.os.name, 'iOS');
+		});
+	});
+});

--- a/test/index.js
+++ b/test/index.js
@@ -20,12 +20,12 @@ function testData () {
 	var data_input_path = path.resolve(__dirname, './test_input');
 	var data_input = String(fs.readFileSync(data_input_path)).split("\n");
 	for(var i = 0; i < data_input.length; ++i) {
-		if(data_input.length == 0) {
+		if(data_input[i].length == 0) {
 			continue;
 		}
 		total_test_num += 1;
 		var tmp_result = new UA(data_input[i]);
-		
+
 		/********* handle browser engine os *********/
 		var tmp_arr = ['browser', 'engine', 'os'];
 		for(var j = 0; j < tmp_arr.length; ++j) {

--- a/test/test_input
+++ b/test/test_input
@@ -3290,3 +3290,9 @@ vivo_Y11iW/V1.0 Linux/3.4.5 Android/4.2.2 Release/02.11.2015 AppleWebKit/537.36 
 vivo_Y613F/V1.0 Linux/3.10.28-svn1131 Android/4.4.4 Release/10.08.2014 AppleWebKit/537.36 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/537.36 System/Android 4.4.4
 vivo_Y622/V1.0 Linux/3.4.5 Android/4.2.2 Release/03.12.2015 AppleWebKit/537.36 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/537.36 System/Android 4.2.2
 vivo_Y628/V1.0 Linux/3.10.28-svn930 Android/4.4.4 Release/09.22.2014 AppleWebKit/537.36 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/537.36 System/Android 4.4.4
+
+
+
+
+Mozilla/5.0 (iPhone 6sp; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 MQQBrowser/7.3 Mobile/14E304 Safari/8536.25 MttCustomUA/2 QBWebViewType/1
+Mozilla/5.0 (iPhone 6sp; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 MQQBrowser/7.4 Mobile/13G36 Safari/8536.25 MttCustomUA/2 QBWebViewType/1 WKType/1


### PR DESCRIPTION
#24 

类似这样的 ua：

Mozilla/5.0 (iPhone 6sp; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 MQQBrowser/7.3 Mobile/14E304 Safari/8536.25 MttCustomUA/2 QBWebViewType/1

Mozilla/5.0 (iPhone 6sp; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 MQQBrowser/7.4 Mobile/13G36 Safari/8536.25 MttCustomUA/2 QBWebViewType/1 WKType/1

被识别成 Mac OS 了， 但感觉应该是 iPhone。