### PR TITLE
修复未能识别百度 HD

### DIFF
--- a/lib/ua-device.js
+++ b/lib/ua-device.js
@@ -514,7 +514,7 @@ module.exports = function (ua) {
         /**
          * Baidu HD
          */
-        else if (match = /baiduhd ([\w.]+)/i.exec(ua)) {
+        else if (match = /baiduhd(?: |\/)([\w.]+)/i.exec(ua)) {
             uaData.browser.name = 'Baidu HD';
             uaData.browser.version = {
                 original: match[1]


### PR DESCRIPTION
这个 UA 会被识别成 safari，但是应该是百度 HD 吧 😂

`Mozilla/5.0 (iPad; CPU OS 7_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) BaiduHD/5.4.0.0 Mobile/10A406 Safari/8536.25`