### PR TITLE
add iOS Chrome browser

### DIFF
--- a/lib/ua-device.js
+++ b/lib/ua-device.js
@@ -613,7 +613,14 @@ module.exports = function (ua) {
          * 'Mozilla/5.0 (iPad; CPU OS 5_1_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B206' belongs to Safari
          */
         else if (/(ipad|iphone).* applewebkit\/.* mobile/i.test(ua)) {
-            uaData.browser.name = 'Safari';
+            // Chrome: Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/67.0.3396.87 Mobile/15F79 Safari/604.1
+            if (tmpMatch = ua.match(/(?:Chrome|CrMo|CriOS)\/([\d\.]*)/)) {
+                uaData.browser.name = 'Chrome';
+                uaData.browser.version = {original: tmpMatch[1]};
+            }
+            else{
+                uaData.browser.name = 'Safari';
+            }
         }
     }
     if (match = ua.match(/baiduboxapp\/?([\d\.]*)/i)) {


### PR DESCRIPTION
iOS上Chrome的UA为： Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) CriOS/67.0.3396.87 Mobile/15F79 Safari/604.1
被识别为Safari了，我看测试用例里面也有，应该也被识别错了。代码ua-device.js的615行mobile的识别到iphone或者ipad就统一为Safari有点欠妥。