### PR TITLE
fix declare variable

### DIFF
--- a/lib/useragent-base.js
+++ b/lib/useragent-base.js
@@ -2742,7 +2742,7 @@ module.exports = (function () {
 
                 if (match = /Windows NT ([0-9]\.[0-9])/.exec(ua)) {
                     this.os.version = parseVersion(match[1]);
-
+                    var match;
                     switch (match[1]) {
                         case '6.2':
                             this.os.version = new Version({


### PR DESCRIPTION
The variable 'match' on line 2741 was not declared, causing an error on some browsers.